### PR TITLE
Add the missing definition for `_I64_MAX`

### DIFF
--- a/src/LibSuiteSparse.jl
+++ b/src/LibSuiteSparse.jl
@@ -6,6 +6,7 @@ using SuiteSparse_jll
 const LONG_MAX = typemax(Clong)
 if Sys.iswindows() && Sys.ARCH === :x86_64
     const __int64 = Int64
+    const _I64_MAX = typemax(Int64)
 end
 
 ## CHOLMOD


### PR DESCRIPTION
fix JuliaSparse/SparseArrays.jl#134 