### PR TITLE
Reproduce the CI failure

### DIFF
--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -1,0 +1,6 @@
+using SuiteSparse
+using Test
+
+@testset "detect_ambiguities" begin
+    @test_nowarn detect_ambiguities(SuiteSparse; recursive=true, ambiguous_bottom=false)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test, Random
 using SuiteSparse, LinearAlgebra, SparseArrays
 
 if Base.USE_GPL_LIBS
+    include("ambiguous.jl")
     include("umfpack.jl")
     include("cholmod.jl")
     include("spqr.jl")


### PR DESCRIPTION
I don't think simply calling `detect_ambiguities` should trigger a segfault. This looks like a bug to me.

```
julia> import SuiteSparse
julia> using Test

julia> detect_ambiguities(SuiteSparse; recursive=true, ambiguous_bottom=false)

signal (11): Segmentation fault: 11
in expression starting at REPL[7]:1
jl_compilation_sig at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:579
cache_method at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:1025
ml_matches at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:3125
jl_matching_methods at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:1891
_methods_by_ftype at ./reflection.jl:901 [inlined]
examine at /Users/gnimuc/Codes/julia-master/julia/usr/share/julia/stdlib/v1.7/Test/src/Test.jl:1597
#detect_ambiguities#45 at /Users/gnimuc/Codes/julia-master/julia/usr/share/julia/stdlib/v1.7/Test/src/Test.jl:1629
detect_ambiguities##kw at /Users/gnimuc/Codes/julia-master/julia/usr/share/julia/stdlib/v1.7/Test/src/Test.jl:1584
unknown function (ip: 0x12e12f858)
_jl_invoke at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:0 [inlined]
jl_apply_generic at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:2425
jl_apply at /Users/gnimuc/Codes/julia-master/julia/src/./julia.h:1760 [inlined]
do_call at /Users/gnimuc/Codes/julia-master/julia/src/interpreter.c:117
eval_stmt_value at /Users/gnimuc/Codes/julia-master/julia/src/interpreter.c:157 [inlined]
eval_body at /Users/gnimuc/Codes/julia-master/julia/src/interpreter.c:571
jl_interpret_toplevel_thunk at /Users/gnimuc/Codes/julia-master/julia/src/interpreter.c:718
jl_toplevel_eval_flex at /Users/gnimuc/Codes/julia-master/julia/src/toplevel.c:884
jl_toplevel_eval_flex at /Users/gnimuc/Codes/julia-master/julia/src/toplevel.c:829
jl_toplevel_eval at /Users/gnimuc/Codes/julia-master/julia/src/toplevel.c:893 [inlined]
jl_toplevel_eval_in at /Users/gnimuc/Codes/julia-master/julia/src/toplevel.c:936
eval at ./boot.jl:369 [inlined]
eval_user_input at /Users/gnimuc/Codes/julia-master/julia/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:150
repl_backend_loop at /Users/gnimuc/Codes/julia-master/julia/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:240
start_repl_backend at /Users/gnimuc/Codes/julia-master/julia/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:225
#run_repl#45 at /Users/gnimuc/Codes/julia-master/julia/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:358
run_repl at /Users/gnimuc/Codes/julia-master/julia/usr/share/julia/stdlib/v1.7/REPL/src/REPL.jl:345
_jl_invoke at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:0 [inlined]
jl_apply_generic at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:2425
#895 at ./client.jl:394
jfptr_YY.895_43598 at /Users/gnimuc/Codes/julia-master/julia/usr/lib/julia/sys.dylib (unknown line)
_jl_invoke at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:0 [inlined]
jl_apply_generic at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:2425
jl_apply at /Users/gnimuc/Codes/julia-master/julia/src/./julia.h:1760 [inlined]
jl_f__call_latest at /Users/gnimuc/Codes/julia-master/julia/src/builtins.c:751
#invokelatest#2 at ./essentials.jl:726 [inlined]
invokelatest at ./essentials.jl:724 [inlined]
run_main_repl at ./client.jl:379
exec_options at ./client.jl:309
_start at ./client.jl:495
jfptr__start_34274 at /Users/gnimuc/Codes/julia-master/julia/usr/lib/julia/sys.dylib (unknown line)
_jl_invoke at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:0 [inlined]
jl_apply_generic at /Users/gnimuc/Codes/julia-master/julia/src/gf.c:2425
jl_apply at /Users/gnimuc/Codes/julia-master/julia/src/./julia.h:1760 [inlined]
true_main at /Users/gnimuc/Codes/julia-master/julia/src/jlapi.c:540
jl_repl_entrypoint at /Users/gnimuc/Codes/julia-master/julia/src/jlapi.c:682
Allocations: 13777400 (Pool: 13775959; Big: 1441); GC: 20

```