### PR TITLE
Fix CHOLMOD version check

### DIFF
--- a/src/cholmod.jl
+++ b/src/cholmod.jl
@@ -182,7 +182,7 @@ function __init__()
                 from www.julialang.org, which ship with the correct
                 versions of all dependencies.
                 """
-        elseif BUILD_VERSION != current_version
+        elseif BUILD_VERSION.major != current_version.major
             @warn """
                 CHOLMOD version incompatibility
 


### PR DESCRIPTION
This check was supposed to ensure major versions match, as the error message indicates.
Introduced by fcaae6f at https://github.com/JuliaLang/julia/pull/38919.

Without this it's very hard to build Julia packages in distributions, as patch version mismatches are common.

@ViralBShah At https://github.com/JuliaLang/julia/pull/38919#issuecomment-820469836 you said
> The PR will kick off the build process. Separately, we should tighten the version checking to closely follow CHOLMOD down to the patch level for now. Both the Yggdrasil PRs and this one should be merged in close succession - with Yggdrasil first. I'm happy to help with the merging.

I don't understand why this was needed, given that making the check stricter merely triggers a warning, which doesn't fix anything in itself. Anyway, can it be removed now? Note that we print a warning too if the version is older than the expected one.