### PR TITLE
Fix LONG_MAX to be typemax(Clonglong) for Win64

### DIFF
--- a/src/LibSuiteSparse.jl
+++ b/src/LibSuiteSparse.jl
@@ -5,11 +5,13 @@ const libumfpack = :libumfpack
 const libcholmod = :libcholmod
 const libspqr = :libspqr
 
-# patches
-const LONG_MAX = typemax(Clong)
+# Special treatment for Win64 since Clong is 32-bit on Win64
 if Sys.iswindows() && Sys.ARCH === :x86_64
-    const __int64 = Int64
-    const _I64_MAX = typemax(Int64)
+    const __int64 = Clonglong
+    const _I64_MAX = typemax(Clonglong)
+    const LONG_MAX = typemax(Clonglong)
+else
+    const LONG_MAX = typemax(Clong)
 end
 
 ## CHOLMOD


### PR DESCRIPTION
Fix the LONG_MAX on win64 which should be 64-bit.

Irrespective of if it helps https://github.com/JuliaLang/SuiteSparse.jl/issues/43, I believe this was incorrect before.

Discussed in https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/00d3d9387671a02d5e8ea8753faa8db050ae276b/SuiteSparse_config/SuiteSparse_config.h#L23