### PR TITLE
Move threaded testsets to main process to reduce Base test noise

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,22 +11,30 @@ if Base.USE_GPL_LIBS
     include("linalg_tests.jl")
 
     # Test multithreaded execution
-    let p, cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads.jl`
+    @testset "threaded SuiteSparse tests" verbose = true begin
+        @testset "threads = $(Threads.nthreads())" begin
+            include("threads.jl")
+        end
         # test both nthreads==1 and nthreads>1. spawn a process to test whichever
         # case we are not running currently.
         other_nthreads = Threads.nthreads() == 1 ? 4 : 1
-        p = run(
-                pipeline(
-                    setenv(
-                        cmd,
-                        "JULIA_NUM_THREADS" => other_nthreads,
-                        dir=@__DIR__()),
-                    stdout = stdout,
-                    stderr = stderr),
-                wait = false)
-        include("threads.jl")
-        if !success(p)
-            error("SuiteSparse threads test failed with nthreads == $other_nthreads")
+        @testset "threads = $other_nthreads" begin
+            let p, cmd = `$(Base.julia_cmd()) --depwarn=error --startup-file=no threads.jl`
+                p = run(
+                        pipeline(
+                            setenv(
+                                cmd,
+                                "JULIA_NUM_THREADS" => other_nthreads,
+                                dir=@__DIR__()),
+                            stdout = stdout,
+                            stderr = stderr),
+                        wait = false)
+                if !success(p)
+                    error("SuiteSparse threads test failed with nthreads == $other_nthreads")
+                else
+                    @test true # mimic the one @test in threads.jl
+                end
+            end
         end
     end
 end

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -2,21 +2,19 @@
 
 using Test, LinearAlgebra, SparseArrays
 
-@testset "threaded SuiteSparse tests" begin
-    A = sprandn(200, 200, 0.2)
-    b = rand(200)
+A = sprandn(200, 200, 0.2)
+b = rand(200)
 
-    function test(n::Integer)
-        _A = A[1:n, 1:n]
-        _b = b[1:n]
-        x = qr(_A) \ _b
-        return norm(x)
-    end
-
-    res_threads = zeros(100)
-    Threads.@threads for i in 1:100
-        res_threads[i] = test(i + 100)
-    end
-
-    @test res_threads ≈ [test(i + 100) for i in 1:100]
+function test(n::Integer)
+    _A = A[1:n, 1:n]
+    _b = b[1:n]
+    x = qr(_A) \ _b
+    return norm(x)
 end
+
+res_threads = zeros(100)
+Threads.@threads for i in 1:100
+    res_threads[i] = test(i + 100)
+end
+
+@test res_threads ≈ [test(i + 100) for i in 1:100]


### PR DESCRIPTION
Moving the `@testset` out of the child process here means it won't leak into the printing in Base tests like:

```
Statistics                               (5) |    95.59 |   3.37 |  3.5 |    6592.22 |  2666.43
      From worker 7:	Test Summary:              | Pass  Total   Time
      From worker 7:	threaded SuiteSparse tests |    1      1  29.8s
SuiteSparse                              (7) |   242.43 |   5.38 |  2.2 |   11184.90 |  2365.01
```

Noticed while reducing the noise in Base tests https://github.com/JuliaLang/julia/pull/44444