### PR TITLE
Add docstrings to local docs, add citations to docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@
 This package ships as part of the Julia stdlib.
 
 SuiteSparse.jl provides Julia wrappers for the [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) library, and provides Julia's sparse linear algebra capabilities - specifically the solvers.
+
+If you use this package in an academic work please cite [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) as well as the individual components you used. The bibtex entries may be found [here](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/CITATION.bib).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,7 @@ Sparse matrix solvers call functions from [SuiteSparse](http://suitesparse.com).
 | `SuiteSparse.UMFPACK.UmfpackLU`   | LU factorization                              |
 | `SuiteSparse.SPQR.QRSparse`       | QR factorization                              |
 
-Other solvers such as [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl/) are as external packages. [Arpack.jl](https://julialinearalgebra.github.io/Arpack.jl/stable/) provides `eigs` and `svds` for iterative solution of eigensystems and singular value decompositions.
+Other solvers such as [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl/) are available as external packages. [Arpack.jl](https://julialinearalgebra.github.io/Arpack.jl/stable/) provides `eigs` and `svds` for iterative solution of eigensystems and singular value decompositions.
 
 These factorizations are described in more detail in [`Linear Algebra`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/) section of the manual:
 1. [`cholesky`](@ref)
@@ -35,7 +35,6 @@ SuiteSparse.CHOLMOD.lowrankdowndate
 SuiteSparse.CHOLMOD.lowrankdowndate!
 SuiteSparse.CHOLMOD.lowrankupdowndate!
 ```
-
 
 ```@meta
 DocTestSetup = nothing

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,11 +14,19 @@ Sparse matrix solvers call functions from [SuiteSparse](http://suitesparse.com).
 
 Other solvers such as [Pardiso.jl](https://github.com/JuliaSparse/Pardiso.jl/) are as external packages. [Arpack.jl](https://julialinearalgebra.github.io/Arpack.jl/stable/) provides `eigs` and `svds` for iterative solution of eigensystems and singular value decompositions.
 
-These factorizations are described in the [`Linear Algebra`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/) section of the manual:
+These factorizations are described in more detail in [`Linear Algebra`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/) section of the manual:
 1. [`cholesky`](@ref)
 2. [`ldlt`](@ref)
 3. [`lu`](@ref)
 4. [`qr`](@ref)
+
+```@docs
+SuiteSparse.CHOLMOD.cholesky
+SuiteSparse.CHOLMOD.cholesky!
+SuiteSparse.CHOLMOD.ldlt
+SuiteSparse.SPQR.qr
+SuiteSparse.UMFPACK.lu
+```
 
 ```@docs
 SuiteSparse.CHOLMOD.lowrankupdate

--- a/src/cholmod.jl
+++ b/src/cholmod.jl
@@ -1282,13 +1282,22 @@ true
 ```
 
 !!! note
-    This method uses the CHOLMOD library from SuiteSparse, which only supports
-    doubles or complex doubles. Input matrices not of those element types will
+    This method uses the CHOLMOD[^ACM887][^DavisHager2009][^ACM836][^ACM837] library from [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse). 
+    CHOLMOD only supports double or complex double element types. 
+    Input matrices not of those element types will
     be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}`
     as appropriate.
 
     Many other functions from CHOLMOD are wrapped but not exported from the
     `Base.SparseArrays.CHOLMOD` module.
+
+[^ACM887]: Chen, Y., Davis, T. A., Hager, W. W., & Rajamanickam, S. (2008). Algorithm 887: CHOLMOD, Supernodal Sparse Cholesky Factorization and Update/Downdate. ACM Trans. Math. Softw., 35(3). [doi:10.1145/1391989.1391995](https://doi.org/10.1145/1391989.1391995)
+
+[^DavisHager2009]: Davis, Timothy A., & Hager, W. W. (2009). Dynamic Supernodes in Sparse Cholesky Update/Downdate and Triangular Solves. ACM Trans. Math. Softw., 35(4). [doi:10.1145/1462173.1462176](https://doi.org/10.1145/1462173.1462176)
+
+[^ACM836]: Davis, Timothy A., Gilbert, J. R., Larimore, S. I., & Ng, E. G. (2004b). Algorithm 836: COLAMD, a Column Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 377–380. [doi:10.1145/1024074.1024080](https://doi.org/10.1145/1024074.1024080)
+
+[^ACM837]: Amestoy, P. R., Davis, T. A., & Duff, I. S. (2004). Algorithm 837: AMD, an Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 381–388. [doi:10.1145/1024074.1024081](https://doi.org/10.1145/1024074.1024081)
 """
 cholesky(A::Union{SparseMatrixCSC{T}, SparseMatrixCSC{Complex{T}},
     Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},
@@ -1320,7 +1329,7 @@ have the type tag, it must still be symmetric or Hermitian.
 See also [`ldlt`](@ref).
 
 !!! note
-    This method uses the CHOLMOD library from SuiteSparse, which only supports
+    This method uses the CHOLMOD library from [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse), which only supports
     doubles or complex doubles. Input matrices not of those element types will
     be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}`
     as appropriate.
@@ -1381,13 +1390,21 @@ it should be a permutation of `1:size(A,1)` giving the ordering to use
 (instead of CHOLMOD's default AMD ordering).
 
 !!! note
-    This method uses the CHOLMOD library from SuiteSparse, which only supports
-    doubles or complex doubles. Input matrices not of those element types will
+    This method uses the CHOLMOD[^ACM887][^DavisHager2009][^ACM836][^ACM837] library from [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse).
+    CHOLMOD only supports double or complex double element types. Input matrices not of those element types will
     be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}`
     as appropriate.
 
     Many other functions from CHOLMOD are wrapped but not exported from the
     `Base.SparseArrays.CHOLMOD` module.
+
+[^ACM887]: Chen, Y., Davis, T. A., Hager, W. W., & Rajamanickam, S. (2008). Algorithm 887: CHOLMOD, Supernodal Sparse Cholesky Factorization and Update/Downdate. ACM Trans. Math. Softw., 35(3). [doi:10.1145/1391989.1391995](https://doi.org/10.1145/1391989.1391995)
+
+[^DavisHager2009]: Davis, Timothy A., & Hager, W. W. (2009). Dynamic Supernodes in Sparse Cholesky Update/Downdate and Triangular Solves. ACM Trans. Math. Softw., 35(4). [doi:10.1145/1462173.1462176](https://doi.org/10.1145/1462173.1462176)
+
+[^ACM836]: Davis, Timothy A., Gilbert, J. R., Larimore, S. I., & Ng, E. G. (2004b). Algorithm 836: COLAMD, a Column Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 377–380. [doi:10.1145/1024074.1024080](https://doi.org/10.1145/1024074.1024080)
+
+[^ACM837]: Amestoy, P. R., Davis, T. A., & Duff, I. S. (2004). Algorithm 837: AMD, an Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 381–388. [doi:10.1145/1024074.1024081](https://doi.org/10.1145/1024074.1024081)
 """
 ldlt(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}},
     Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},

--- a/src/cholmod.jl
+++ b/src/cholmod.jl
@@ -1294,10 +1294,6 @@ true
 [^ACM887]: Chen, Y., Davis, T. A., Hager, W. W., & Rajamanickam, S. (2008). Algorithm 887: CHOLMOD, Supernodal Sparse Cholesky Factorization and Update/Downdate. ACM Trans. Math. Softw., 35(3). [doi:10.1145/1391989.1391995](https://doi.org/10.1145/1391989.1391995)
 
 [^DavisHager2009]: Davis, Timothy A., & Hager, W. W. (2009). Dynamic Supernodes in Sparse Cholesky Update/Downdate and Triangular Solves. ACM Trans. Math. Softw., 35(4). [doi:10.1145/1462173.1462176](https://doi.org/10.1145/1462173.1462176)
-
-[^ACM836]: Davis, Timothy A., Gilbert, J. R., Larimore, S. I., & Ng, E. G. (2004b). Algorithm 836: COLAMD, a Column Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 377–380. [doi:10.1145/1024074.1024080](https://doi.org/10.1145/1024074.1024080)
-
-[^ACM837]: Amestoy, P. R., Davis, T. A., & Duff, I. S. (2004). Algorithm 837: AMD, an Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 381–388. [doi:10.1145/1024074.1024081](https://doi.org/10.1145/1024074.1024081)
 """
 cholesky(A::Union{SparseMatrixCSC{T}, SparseMatrixCSC{Complex{T}},
     Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},
@@ -1397,14 +1393,6 @@ it should be a permutation of `1:size(A,1)` giving the ordering to use
 
     Many other functions from CHOLMOD are wrapped but not exported from the
     `Base.SparseArrays.CHOLMOD` module.
-
-[^ACM887]: Chen, Y., Davis, T. A., Hager, W. W., & Rajamanickam, S. (2008). Algorithm 887: CHOLMOD, Supernodal Sparse Cholesky Factorization and Update/Downdate. ACM Trans. Math. Softw., 35(3). [doi:10.1145/1391989.1391995](https://doi.org/10.1145/1391989.1391995)
-
-[^DavisHager2009]: Davis, Timothy A., & Hager, W. W. (2009). Dynamic Supernodes in Sparse Cholesky Update/Downdate and Triangular Solves. ACM Trans. Math. Softw., 35(4). [doi:10.1145/1462173.1462176](https://doi.org/10.1145/1462173.1462176)
-
-[^ACM836]: Davis, Timothy A., Gilbert, J. R., Larimore, S. I., & Ng, E. G. (2004b). Algorithm 836: COLAMD, a Column Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 377–380. [doi:10.1145/1024074.1024080](https://doi.org/10.1145/1024074.1024080)
-
-[^ACM837]: Amestoy, P. R., Davis, T. A., & Duff, I. S. (2004). Algorithm 837: AMD, an Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 381–388. [doi:10.1145/1024074.1024081](https://doi.org/10.1145/1024074.1024081)
 """
 ldlt(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}},
     Symmetric{T,SparseMatrixCSC{T,SuiteSparse_long}},

--- a/src/spqr.jl
+++ b/src/spqr.jl
@@ -189,10 +189,6 @@ Column permutation:
 ```
 
 [^ACM933]: Foster, L. V., & Davis, T. A. (2013). Algorithm 933: Reliable Calculation of Numerical Rank, Null Space Bases, Pseudoinverse Solutions, and Basic Solutions Using SuitesparseQR. ACM Trans. Math. Softw., 40(1). [doi:10.1145/2513109.2513116](https://doi.org/10.1145/2513109.2513116)
-
-[^ACM836]: Davis, Timothy A., Gilbert, J. R., Larimore, S. I., & Ng, E. G. (2004b). Algorithm 836: COLAMD, a Column Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 377–380. [doi:10.1145/1024074.1024080](https://doi.org/10.1145/1024074.1024080)
-
-[^ACM837]: Amestoy, P. R., Davis, T. A., & Duff, I. S. (2004). Algorithm 837: AMD, an Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 381–388. [doi:10.1145/1024074.1024081](https://doi.org/10.1145/1024074.1024081)
 """
 function LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Tv <: CHOLMOD.VTypes}
     R     = Ref{Ptr{CHOLMOD.cholmod_sparse}}()

--- a/src/spqr.jl
+++ b/src/spqr.jl
@@ -147,10 +147,10 @@ _default_tol(A::SparseMatrixCSC) =
 
 Compute the `QR` factorization of a sparse matrix `A`. Fill-reducing row and column permutations
 are used such that `F.R = F.Q'*A[F.prow,F.pcol]`. The main application of this type is to
-solve least squares or underdetermined problems with [`\\`](@ref). The function calls the C library SPQR.
+solve least squares or underdetermined problems with [`\\`](@ref). The function calls the C library SPQR[^ACM933][^ACM836][^ACM837].
 
 !!! note
-    `qr(A::SparseMatrixCSC)` uses the SPQR library that is part of SuiteSparse.
+    `qr(A::SparseMatrixCSC)` uses the SPQR library that is part of [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse).
     As this library only supports sparse matrices with [`Float64`](@ref) or
     `ComplexF64` elements, as of Julia v1.4 `qr` converts `A` into a copy that is
     of type `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
@@ -187,6 +187,12 @@ Column permutation:
  1
  2
 ```
+
+[^ACM933]: Foster, L. V., & Davis, T. A. (2013). Algorithm 933: Reliable Calculation of Numerical Rank, Null Space Bases, Pseudoinverse Solutions, and Basic Solutions Using SuitesparseQR. ACM Trans. Math. Softw., 40(1). [doi:10.1145/2513109.2513116](https://doi.org/10.1145/2513109.2513116)
+
+[^ACM836]: Davis, Timothy A., Gilbert, J. R., Larimore, S. I., & Ng, E. G. (2004b). Algorithm 836: COLAMD, a Column Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 377–380. [doi:10.1145/1024074.1024080](https://doi.org/10.1145/1024074.1024080)
+
+[^ACM837]: Amestoy, P. R., Davis, T. A., & Duff, I. S. (2004). Algorithm 837: AMD, an Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 381–388. [doi:10.1145/1024074.1024081](https://doi.org/10.1145/1024074.1024081)
 """
 function LinearAlgebra.qr(A::SparseMatrixCSC{Tv}; tol=_default_tol(A), ordering=ORDERING_DEFAULT) where {Tv <: CHOLMOD.VTypes}
     R     = Ref{Ptr{CHOLMOD.cholmod_sparse}}()

--- a/src/umfpack.jl
+++ b/src/umfpack.jl
@@ -186,11 +186,20 @@ The relation between `F` and `A` is
 - [`\\`](@ref)
 - [`det`](@ref)
 
+See also [`lu!`](@ref)
+
 !!! note
-    `lu(A::SparseMatrixCSC)` uses the UMFPACK library that is part of
-    SuiteSparse. As this library only supports sparse matrices with [`Float64`](@ref) or
+    `lu(A::SparseMatrixCSC)` uses the UMFPACK[^ACM832][^ACM836][^ACM837] library that is part of
+    [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse). 
+    As this library only supports sparse matrices with [`Float64`](@ref) or
     `ComplexF64` elements, `lu` converts `A` into a copy that is of type
     `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
+
+[^ACM832]: Davis, Timothy A. (2004b). Algorithm 832: UMFPACK V4.3---an Unsymmetric-Pattern Multifrontal Method. ACM Trans. Math. Softw., 30(2), 196–199. [doi:10.1145/992200.992206](https://doi.org/10.1145/992200.992206)
+
+[^ACM836]: Davis, Timothy A., Gilbert, J. R., Larimore, S. I., & Ng, E. G. (2004b). Algorithm 836: COLAMD, a Column Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 377–380. [doi:10.1145/1024074.1024080](https://doi.org/10.1145/1024074.1024080)
+
+[^ACM837]: Amestoy, P. R., Davis, T. A., & Duff, I. S. (2004). Algorithm 837: AMD, an Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 381–388. [doi:10.1145/1024074.1024081](https://doi.org/10.1145/1024074.1024081)
 """
 function lu(S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes}; check::Bool = true)
     zerobased = getcolptr(S)[1] == 0
@@ -232,6 +241,8 @@ to create the LU factorization `F`, otherwise an error is thrown.
 When `check = true`, an error is thrown if the decomposition fails.
 When `check = false`, responsibility for checking the decomposition's
 validity (via [`issuccess`](@ref)) lies with the user.
+
+See also [`lu`](@ref)
 
 !!! note
     `lu!(F::UmfpackLU, A::SparseMatrixCSC)` uses the UMFPACK library that is part of

--- a/src/umfpack.jl
+++ b/src/umfpack.jl
@@ -196,10 +196,6 @@ See also [`lu!`](@ref)
     `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
 
 [^ACM832]: Davis, Timothy A. (2004b). Algorithm 832: UMFPACK V4.3---an Unsymmetric-Pattern Multifrontal Method. ACM Trans. Math. Softw., 30(2), 196–199. [doi:10.1145/992200.992206](https://doi.org/10.1145/992200.992206)
-
-[^ACM836]: Davis, Timothy A., Gilbert, J. R., Larimore, S. I., & Ng, E. G. (2004b). Algorithm 836: COLAMD, a Column Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 377–380. [doi:10.1145/1024074.1024080](https://doi.org/10.1145/1024074.1024080)
-
-[^ACM837]: Amestoy, P. R., Davis, T. A., & Duff, I. S. (2004). Algorithm 837: AMD, an Approximate Minimum Degree Ordering Algorithm. ACM Trans. Math. Softw., 30(3), 381–388. [doi:10.1145/1024074.1024081](https://doi.org/10.1145/1024074.1024081)
 """
 function lu(S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes}; check::Bool = true)
     zerobased = getcolptr(S)[1] == 0


### PR DESCRIPTION
@ViralBShah. This does have the issue of many duplicate footnote bodies. Each docstring cannot see the footnotes of the others. However, for the HTML docs this will cause every docstring to place their own _identical_ copies of the same citation. This is particularly a problem for AMD and and COLAMD which are cited in many of the docstrings. See https://github.com/JuliaDocs/Documenter.jl/pull/1464.