### PR TITLE
Remove extra citations that don't have corresponding footnotes

### DIFF
--- a/src/cholmod.jl
+++ b/src/cholmod.jl
@@ -1282,7 +1282,7 @@ true
 ```
 
 !!! note
-    This method uses the CHOLMOD[^ACM887][^DavisHager2009][^ACM836][^ACM837] library from [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse). 
+    This method uses the CHOLMOD[^ACM887][^DavisHager2009] library from [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse). 
     CHOLMOD only supports double or complex double element types. 
     Input matrices not of those element types will
     be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}`
@@ -1386,7 +1386,7 @@ it should be a permutation of `1:size(A,1)` giving the ordering to use
 (instead of CHOLMOD's default AMD ordering).
 
 !!! note
-    This method uses the CHOLMOD[^ACM887][^DavisHager2009][^ACM836][^ACM837] library from [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse).
+    This method uses the CHOLMOD[^ACM887][^DavisHager2009] library from [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse).
     CHOLMOD only supports double or complex double element types. Input matrices not of those element types will
     be converted to `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}`
     as appropriate.

--- a/src/spqr.jl
+++ b/src/spqr.jl
@@ -147,7 +147,7 @@ _default_tol(A::SparseMatrixCSC) =
 
 Compute the `QR` factorization of a sparse matrix `A`. Fill-reducing row and column permutations
 are used such that `F.R = F.Q'*A[F.prow,F.pcol]`. The main application of this type is to
-solve least squares or underdetermined problems with [`\\`](@ref). The function calls the C library SPQR[^ACM933][^ACM836][^ACM837].
+solve least squares or underdetermined problems with [`\\`](@ref). The function calls the C library SPQR[^ACM933].
 
 !!! note
     `qr(A::SparseMatrixCSC)` uses the SPQR library that is part of [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse).

--- a/src/umfpack.jl
+++ b/src/umfpack.jl
@@ -189,7 +189,7 @@ The relation between `F` and `A` is
 See also [`lu!`](@ref)
 
 !!! note
-    `lu(A::SparseMatrixCSC)` uses the UMFPACK[^ACM832][^ACM836][^ACM837] library that is part of
+    `lu(A::SparseMatrixCSC)` uses the UMFPACK[^ACM832] library that is part of
     [SuiteSparse](https://github.com/DrTimothyAldenDavis/SuiteSparse). 
     As this library only supports sparse matrices with [`Float64`](@ref) or
     `ComplexF64` elements, `lu` converts `A` into a copy that is of type


### PR DESCRIPTION
These citations should already be taken care of by the primary papers.

This might be part of the errors on docs.