### PR TITLE
Move three `const ___ = SparseArrays.___` lines into an `if Base.USE_GPL_LIBS` block

### DIFF
--- a/src/SuiteSparse.jl
+++ b/src/SuiteSparse.jl
@@ -9,8 +9,11 @@ const decrement = SparseArrays.decrement
 const decrement! = SparseArrays.decrement!
 
 const LibSuiteSparse = SparseArrays.LibSuiteSparse
-const CHOLMOD = SparseArrays.CHOLMOD
-const SPQR = SparseArrays.SPQR
-const UMFPACK = SparseArrays.UMFPACK
+
+if Base.USE_GPL_LIBS
+    const CHOLMOD = SparseArrays.CHOLMOD
+    const SPQR = SparseArrays.SPQR
+    const UMFPACK = SparseArrays.UMFPACK
+end
 
 end # module SuiteSparse


### PR DESCRIPTION
These three names (`SparseArrays.CHOLMOD`, `SparseArrays.SPQR`, and `SparseArrays.UMFPACK`) are not available if if `Base.USE_GPL_LIBS` is `false`.